### PR TITLE
Require Ruby 2.5 + use stdlib #transform_keys!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - '2.3'
+  - '2.5'
   - '2.6'
 
 before_install:

--- a/halogen.gemspec
+++ b/halogen.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.3'
+  spec.required_ruby_version = '~> 2.5'
 
   spec.add_dependency 'json', '~> 2.3.0'
 

--- a/lib/halogen/hash_util.rb
+++ b/lib/halogen/hash_util.rb
@@ -9,7 +9,7 @@ module Halogen
     # @return [Hash]
     #
     def stringify_keys!(hash)
-      transform_keys!(hash, &:to_s)
+      hash.transform_keys!(&:to_s)
     end
 
     # Transform hash keys into symbols if necessary
@@ -19,19 +19,7 @@ module Halogen
     # @return [Hash]
     #
     def symbolize_keys!(hash)
-      transform_keys!(hash, &:to_sym)
-    end
-
-    # Transform hash keys according to block
-    #
-    # @param hash [Hash]
-    #
-    # @return [Hash]
-    #
-    def transform_keys!(hash)
-      hash.keys.each { |key| hash[yield(key)] = hash.delete(key) }
-
-      hash
+      hash.transform_keys!(&:to_sym)
     end
   end
 end


### PR DESCRIPTION
Ups the minimum Ruby version to 2.5. With 2.5, Ruby stdlib implements `#transform_keys!` in C. Using this implementation results in a 1% performance gain on large data sets compared to using `#each`.