### PR TITLE
Include links optionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ link(:find, :templated) { '/goats/{?id}' }
 # => { _links: { find: { href: '/goats/{?id}', templated: true } } ... }
 ```
 
+Optional links:
+
+```ruby
+representer = MyRepresenterWithManyLinks.new(include_links: false)
+representation = representer.render
+representation[:links] #nil
+```
+
 #### Embedded resources
 
 Embedded resources are not rendered by default. They will be included if both

--- a/lib/halogen/links.rb
+++ b/lib/halogen/links.rb
@@ -18,7 +18,11 @@ module Halogen
       # @return [Hash] the rendered hash with links, if any
       #
       def render
-        decorate_render :links, super
+        if options.fetch(:include_links, true)
+          decorate_render :links, super
+        else
+          super
+        end
       end
 
       # @return [Hash] links from definitions

--- a/spec/halogen/links_spec.rb
+++ b/spec/halogen/links_spec.rb
@@ -95,8 +95,6 @@ describe Halogen::Links do
 
       it "excludes links when false" do
         link = klass.link(:self, :templated, foo: 'foo', attrs: { bar: 'bar' }) { 'path' }
-        repr = klass.new('include_links'  => true)        
-
         repr = klass.new('include_links'  => false)
         expect(repr.options).to eq({include_links: false})
         

--- a/spec/halogen/links_spec.rb
+++ b/spec/halogen/links_spec.rb
@@ -94,7 +94,7 @@ describe Halogen::Links do
         
         render = repr.render
 
-        expect(render[:links]).to eq(nil)
+        expect(render[:_links]).to eq(nil)
       end
     end
   

--- a/spec/halogen/links_spec.rb
+++ b/spec/halogen/links_spec.rb
@@ -68,6 +68,36 @@ describe Halogen::Links do
   end
 
   describe Halogen::Links::InstanceMethods do
+    describe "options[:include_links]" do
+      let :klass do
+        Class.new do
+          include Halogen
+        end
+      end
+      
+      it "includes links when true" do
+        link = klass.link(:self, :templated, foo: 'foo', attrs: { bar: 'bar' }) { 'path' }
+        repr = klass.new('include_links'  => true)        
+
+        expect(repr.options).to eq({include_links: true})
+        render = repr.render
+
+        expect(render[:_links]).to eq(:self => {:bar=>"bar", :href=>"path", :templated=>true})
+      end
+
+      it "excludes links when false" do
+        link = klass.link(:self, :templated, foo: 'foo', attrs: { bar: 'bar' }) { 'path' }
+        repr = klass.new('include_links'  => true)        
+
+        repr = klass.new('include_links'  => false)
+        expect(repr.options).to eq({include_links: false})
+        
+        render = repr.render
+
+        expect(render[:links]).to eq(nil)
+      end
+    end
+  
     describe '#links' do
       let :klass do
         Class.new do
@@ -81,7 +111,7 @@ describe Halogen::Links do
         repr = klass.new
 
         expect(repr.links).to eq({})
-      end
+      end      
     end
   end
 end

--- a/spec/halogen/links_spec.rb
+++ b/spec/halogen/links_spec.rb
@@ -111,7 +111,7 @@ describe Halogen::Links do
         repr = klass.new
 
         expect(repr.links).to eq({})
-      end      
+      end
     end
   end
 end

--- a/spec/halogen/links_spec.rb
+++ b/spec/halogen/links_spec.rb
@@ -85,6 +85,14 @@ describe Halogen::Links do
         expect(render[:_links]).to eq(:self => {:bar=>"bar", :href=>"path", :templated=>true})
       end
 
+      it "defaults to true" do
+        link = klass.link(:self, :templated, foo: 'foo', attrs: { bar: 'bar' }) { 'path' }
+        repr = klass.new
+        render = repr.render
+
+        expect(render[:_links]).to eq(:self => {:bar=>"bar", :href=>"path", :templated=>true})
+      end
+
       it "excludes links when false" do
         link = klass.link(:self, :templated, foo: 'foo', attrs: { bar: 'bar' }) { 'path' }
         repr = klass.new('include_links'  => true)        


### PR DESCRIPTION
This adds specs around the `:include_links` option that @bamohan added to Halogen. With these specs in place we should be ready to merge this and then update webapp to point to the latest version.