### PR TITLE
Make compatible with Ruby 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-
-rvm:
-  - '2.5'
-  - '2.6'
-
-before_install:
-  - gem install bundler

--- a/halogen.gemspec
+++ b/halogen.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 3.0'
+  spec.required_ruby_version = '> 2.6', '< 4'
 
-  spec.add_dependency 'json', '~> 2.3.0'
+  spec.add_dependency 'json', '> 2.3.0'
 
   spec.add_development_dependency 'bundler',   '>= 2.0'
   spec.add_development_dependency 'rake',      '~> 13.0'

--- a/halogen.gemspec
+++ b/halogen.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.5'
+  spec.required_ruby_version = '~> 3.0'
 
   spec.add_dependency 'json', '~> 2.3.0'
 

--- a/lib/halogen/version.rb
+++ b/lib/halogen/version.rb
@@ -1,3 +1,3 @@
 module Halogen
-  VERSION = '0.0.8' # :nodoc:
+  VERSION = '0.0.9' # :nodoc:
 end


### PR DESCRIPTION
Make gem compatible with Ruby 3

Test for deprecations: `RUBYOPT="-W:deprecated" bundle exec rspec`

Also removes TravisCI config since we don't use Travis anymore

[JIRA](https://modeanalytics.atlassian.net/browse/UCM-263)